### PR TITLE
Fix header section numbering before start of section 1

### DIFF
--- a/edengfmt.tex
+++ b/edengfmt.tex
@@ -190,9 +190,10 @@
 \newpagestyle{main}[\defaultfont\bfseries]{%
   \headrule%
   \sethead%
-      {\ifthesection{\toptitlemarks\thesection{.}\space}%
+      {\toptitlemarks
+       \ifthesection{\thesection{.}\space}%
           {\ifthechapter{\thechapter{.}\space}{}}%
-       \ifthesection{\toptitlemarks\sectiontitle}%
+       \ifthesection{\sectiontitle}%
           {\ifthechapter{\chaptertitle}{\MakeUppercase{\chaptertitle}}}}%
       {}%
       {\thepage}%
@@ -211,9 +212,10 @@
       [\thepage]%
       []%
       [\ifthechapter{\chaptertitle}{\MakeUppercase{\chaptertitle}}]%
-      {\ifthesection{\toptitlemarks\thesection{.}\space}%
+      {\toptitlemarks
+       \ifthesection{\thesection{.}\space}%
           {\ifthechapter{\thechapter{.}\space}{}}%
-       \ifthesection{\toptitlemarks\sectiontitle}%
+       \ifthesection{\sectiontitle}%
           {\ifthechapter{\chaptertitle}{\MakeUppercase{\chaptertitle}}}}%
       {}%
       {\thepage}%


### PR DESCRIPTION
Currently when setting the section number in the page headers, there is a bug that causes a blank chapter/section number to appear when section 1 has not started, For example, if chapter 1 starts on page 1 and section 1.1 starts half way through page 2, the header on page 2 appears as `. Chapter name` instead of the expected `1. Chapter name`.

This is because the `\toptitlemarks` is wrongly positioned, so the conditional `\ifthesection` evaluates to true (since it sees the section number 1.1 at the end of page 2), but the `\toptitlemarks\thesection` inside doesn't find a valid section number.

Moving the `\toptitlemarks` to the outer scope so `\thesection` is retrieved consistently fixes this bug.